### PR TITLE
Boxy Groups: Allow for field groups to have a converter that takes the boxed field values

### DIFF
--- a/src/main/scala/com/hacklanta/formality/FieldGroup.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldGroup.scala
@@ -30,6 +30,12 @@ object FieldGroup {
 
         case TypeRef(_, thing, other) =>
           (tq"net.liftweb.common.HLists.HNil", Nil, tq"net.liftweb.common.HLists.HNil", Nil)
+
+        case other =>
+          c.abort(
+            c.enclosingPosition,
+            "Couldn't fully resolve field group types; please make sure you declare the field group and converter in the same expression."
+          )
       }
 
     if (hlistTypes.length > 22) {

--- a/src/main/scala/com/hacklanta/formality/FieldGroup.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldGroup.scala
@@ -41,15 +41,7 @@ object FieldGroup {
           initialGroup.converter,
           initialGroup.computeValues,
           initialGroup.bindFields
-        ) {
-          def withConverterFn[T](converter: ($hlistType)=>net.liftweb.common.Box[T]) = {
-            withHlistConverter[T](converter)
-          }
-
-          def withBoxedConverterFn[T](converter: ($boxedHlistType)=>net.liftweb.common.Box[T]) = {
-            withBoxedHlistConverter[T](converter)
-          }
-        }
+        )
       }"""
     } else {
       val (matcher, parameterList) =

--- a/src/test/scala/com/hacklanta/formality/FieldGroupSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/FieldGroupSpec.scala
@@ -93,5 +93,142 @@ class FieldGroupSpec extends Specification {
         case Full(matchResult) => matchResult
       }
     }
+
+    "reflect a caller-specified boxed converter's failure in the field group value" in {
+      val failingFieldGroup =
+        FieldGroupBase(None)
+          .withFields(nameField, ageField)
+          .withBoxedConverter { (name: Box[String], age: Box[Int]) =>
+            Failure("It's all gone wrong!")
+          }
+
+      failingFieldGroup.value must beLike {
+        case Failure(message, Empty, Empty) =>
+          message must_== "It's all gone wrong!"
+      }
+    }
+  }
+
+  "FieldGroups with enough fields to trigger HList-only converters" should {
+    val nameField = MockFieldHolder(Full("Stradivarius"))
+    val ageField = MockFieldHolder(Full(25))
+
+    val fieldGroup =
+      FieldGroupBase(None).withFields(
+        nameField, nameField, nameField, nameField, nameField, nameField, nameField, nameField, nameField, nameField, nameField,
+        ageField, ageField, ageField, ageField, ageField, ageField, ageField, ageField, ageField, ageField, ageField, ageField)
+
+    "allow the caller to group more than 22 constituent fields" in {
+      fieldGroup.value must beLike {
+        case Full(hlist: HList) =>
+          hlist.length must_== 23
+      }
+    }
+
+    "allow the caller to specify a converter that takes an HList of field values and produces a Box" in {
+      val convertibleFieldGroup =
+        fieldGroup.withHlistConverter { valueHlist =>
+          Full(
+            (valueHlist.length must_== 23) and
+            (valueHlist must beLike {
+              case name1 :+: name2 :+: name3 :+: name4 :+: name5 :+: name6 :+: name7 :+: name8 :+: name9 :+: name10 :+: name11 :+:
+                age1 :+: age2 :+: age3 :+: age4 :+: age5 :+: age6 :+: age7 :+: age8 :+: age9 :+: age10 :+: age11 :+: age12 :+: HNil =>
+                name1 must_== "Stradivarius"
+                name2 must_== "Stradivarius"
+                name3 must_== "Stradivarius"
+                name4 must_== "Stradivarius"
+                name5 must_== "Stradivarius"
+                name6 must_== "Stradivarius"
+                name7 must_== "Stradivarius"
+                name8 must_== "Stradivarius"
+                name9 must_== "Stradivarius"
+                name10 must_== "Stradivarius"
+                name11 must_== "Stradivarius"
+                age1 must_== 25
+                age2 must_== 25
+                age3 must_== 25
+                age4 must_== 25
+                age5 must_== 25
+                age6 must_== 25
+                age7 must_== 25
+                age8 must_== 25
+                age9 must_== 25
+                age10 must_== 25
+                age11 must_== 25
+                age12 must_== 25
+            })
+          )
+        }
+
+      convertibleFieldGroup.value must beLike {
+        case Full(matchResult) => matchResult
+      }
+    }
+
+    "reflect a caller-specified Hlist converter's failure in the field group value" in {
+      val failingFieldGroup =
+        fieldGroup
+          .withHlistConverter { values =>
+            Failure("It's all gone wrong!")
+          }
+
+      failingFieldGroup.value must beLike {
+        case Failure(message, Empty, Empty) =>
+          message must_== "It's all gone wrong!"
+      }
+    }
+
+    "allow the caller to specify a converter that takes an HList of boxed field values and produces a Box" in {
+      val boxConvertibleFieldGroup =
+        fieldGroup
+          .withBoxedHlistConverter { boxedHlist =>
+            Full(
+              boxedHlist must beLike {
+                case name1 :+: name2 :+: name3 :+: name4 :+: name5 :+: name6 :+: name7 :+: name8 :+: name9 :+: name10 :+: name11 :+:
+                  age1 :+: age2 :+: age3 :+: age4 :+: age5 :+: age6 :+: age7 :+: age8 :+: age9 :+: age10 :+: age11 :+: age12 :+: HNil =>
+                  name1 must_== Full("Stradivarius")
+                  name2 must_== Full("Stradivarius")
+                  name3 must_== Full("Stradivarius")
+                  name4 must_== Full("Stradivarius")
+                  name5 must_== Full("Stradivarius")
+                  name6 must_== Full("Stradivarius")
+                  name7 must_== Full("Stradivarius")
+                  name8 must_== Full("Stradivarius")
+                  name9 must_== Full("Stradivarius")
+                  name10 must_== Full("Stradivarius")
+                  name11 must_== Full("Stradivarius")
+                  age1 must_== Full(25)
+                  age2 must_== Full(25)
+                  age3 must_== Full(25)
+                  age4 must_== Full(25)
+                  age5 must_== Full(25)
+                  age6 must_== Full(25)
+                  age7 must_== Full(25)
+                  age8 must_== Full(25)
+                  age9 must_== Full(25)
+                  age10 must_== Full(25)
+                  age11 must_== Full(25)
+                  age12 must_== Full(25)
+              }
+            )
+          }
+
+      boxConvertibleFieldGroup.value must beLike {
+        case Full(matchResult) => matchResult
+      }
+    }
+
+    "reflect a caller-specified boxed HList converter's failure in the field group value" in {
+      val failingFieldGroup =
+        fieldGroup
+          .withBoxedHlistConverter { boxedHlist =>
+            Failure("It's all gone wrong!")
+          }
+
+      failingFieldGroup.value must beLike {
+        case Failure(message, Empty, Empty) =>
+          message must_== "It's all gone wrong!"
+      }
+    }
   }
 }

--- a/src/test/scala/com/hacklanta/formality/FieldGroupSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/FieldGroupSpec.scala
@@ -77,5 +77,21 @@ class FieldGroupSpec extends Specification {
           person.age must_== 25
       }
     }
+
+    "allow the caller to specify a converter that takes boxed field values and produces a Box" in {
+      val fieldGroup =
+        FieldGroupBase(None)
+          .withFields(nameField, ageField)
+          .withBoxedConverter { (name: Box[String], age: Box[Int]) =>
+            Full(
+              (name must_== Full("Stradivarius")) and
+              (age must_== Full(25))
+           )
+          }
+
+      fieldGroup.value must beLike {
+        case Full(matchResult) => matchResult
+      }
+    }
   }
 }


### PR DESCRIPTION
`withBoxedConverter` takes the boxed versions of the fields. It can be very useful
to implement a situation where the user can set one of two fields, and the
result is contingent on both fields. One example is a situation where something
can be either pasted into a text box or uploaded---the result may always be one
`String` (or, conversely, always be one array of bytes), but we have to choose
between two fields, one of which was potentially left empty. The current field
group converter, which only takes the unboxed parameter values, would simply
always fail in these cases, because it wouldn't have values for all the fields and
the converter would therefore never be called.

Tangentially, also added a friendlier error in cases where we can't resolve the
types of a field group when we try to formalize it and macro-attach the helper
functions that allow `withConverter`, `withBoxedConverter`, and `as` to work.

Still missing:
- [x] Adding a note about this to the README.
