### PR TITLE
Value Pacifier: Leave value attribute unchanged when no default field value is specified.

### DIFF
--- a/src/main/scala/com/hacklanta/formality/FieldHandling.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldHandling.scala
@@ -159,8 +159,14 @@ abstract class BaseFieldHolder[
   protected def baseTransform: CssSel = {
     val functionId = generateFunctionIdAndHandler
 
-    (selector + " [name]") #> functionId &
-    (selector + " [value]") #> initialValue.map(serializeValue _)
+    val nameTransform = (selector + " [name]") #> functionId
+
+    initialValue.map { startValue =>
+      nameTransform &
+      (selector + " [value]") #> serializeValue(startValue)
+    } getOrElse {
+      nameTransform
+    }
   }
 
   /**

--- a/src/test/scala/com/hacklanta/formality/FieldSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/FieldSpec.scala
@@ -13,7 +13,7 @@ import net.liftweb.util._
 import Formality._
 
 class FieldSpec extends Specification {
-  val templateElement = <div class="boomdayada boomdayadan" data-test-attribute="bam">Here's a test!</div>
+  val templateElement = <div class="boomdayada boomdayadan" data-test-attribute="bam" value="markup-value">Here's a test!</div>
 
   "Simple fields with no initial value" should {
     "only bind the name attribute" in new SScope {
@@ -25,9 +25,9 @@ class FieldSpec extends Specification {
         "div",
         "class" -> "boomdayada boomdayadan",
         "data-test-attribute" -> "bam",
+        "value" -> "markup-value",
         "name" -> ".*"
       )
-      (resultingMarkup \ "div" \ "@value").text must_== ""
     }
   }
   


### PR DESCRIPTION
Until now, not specifying a default field value would clear any default value
that was specified in the markup. We now adhere to our principle of respecting
the markup in all possible cases by leaving the default value in the markup
untouched unless the caller explicitly sets a default value (which can be
blank for string values).

In cases where the caller wants to specify a blank default, and the markup has
a value specified, they can use a separate CSS transform to clear the value and
be explicit about that preference.

Fixes #2 .
