### PR TITLE
Empty Field Magic: Pass through Empty fields if there are no validation failures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "lift-formality"
 
 organization := "com.hacklanta"
 
-version := "1.0.0"
+version := "1.1.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/com/hacklanta/formality/FieldHandling.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldHandling.scala
@@ -200,7 +200,11 @@ abstract class BaseFieldHolder[
 
         addValidationErrors(validationErrors: _*)
 
-        Failure("Empty field failed validation.") ~> validationErrors
+        if (validationErrors.nonEmpty) {
+          Failure("Empty field failed validation.") ~> validationErrors
+        } else {
+          Empty
+        }
       case other =>
         other
     }

--- a/src/test/scala/com/hacklanta/formality/ValidationSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/ValidationSpec.scala
@@ -143,6 +143,35 @@ class ValidationSpec extends Specification {
       }
     }
 
+    "report the field as Empty if no boxed validations exist and there is no value for the field" in new IntFieldScope {
+      override def parametersForForm(intFieldName: Option[String], intFieldValue: String) = {
+        Nil
+      }
+
+      var seenFailures = List[Failure]()
+
+      val testForm = form.withField(formField).formalize onFailure {
+        case failures =>
+          seenFailures = failures
+      }
+
+      val fieldName = bindAndSubmitForm(testForm.binder)
+
+      seenFailures.length must_== 1
+      seenFailures must beLike {
+        case List(Failure(message, Empty, Empty)) =>
+          message must_== "Empty"
+      }
+
+      fieldName must beLike {
+        case Some(fieldName) =>
+          S.errors collect {
+            case (error, Full(name)) if fieldName == name =>
+              error
+          } must beEmpty
+      }
+    }
+
     "handle boxed validations even if there is no value for the field" in new IntFieldScope {
       override def parametersForForm(intFieldName: Option[String], intFieldValue: String) = {
         Nil


### PR DESCRIPTION
In #9, we added support for validating fields that weren't sent to
the server. However, that PR also makes it so that any field that
doesn't make it to the server *always* manifests as a `Failure`.
We now change that so that it only manifests as a `Failure` if
there are boxed validations for that field and they fail. If instead
there are no validation failures, either because there are no
validations that handle the empty form of the field, or because
those validations passed, then we now provide the field value as
`Empty`.

For top-level forms, this will still result in `onSuccess` not being
called. However, for field converters that can accept boxes for
the field values, a distinction can be made between `Empty` and
`Failure`.