### PR TITLE
Debate Club: Allow optional selector in Formality.fieldGroup call.

### DIFF
--- a/src/main/scala/com/hacklanta/formality/Formality.scala
+++ b/src/main/scala/com/hacklanta/formality/Formality.scala
@@ -106,6 +106,7 @@ object Formality extends FieldValueHelpers {
 
   def form = FormalityFormProto()
   def fieldGroup = FieldGroup()
+  def fieldGroup(scopingSelector: String) = FieldGroup(scopingSelector)
 
   val :: = HListies.:+:
   val :+: = HListies.:+:


### PR DESCRIPTION
We didn't have an overload, so if you wanted to create a fieldGroup with a
scoping selector, you had to call the `FieldGroup` constructor directly.

Fixes #18.