### PR TITLE
Defaultification: Gives textareas a default as well as non-String fields.

### DIFF
--- a/src/main/scala/com/hacklanta/formality/FieldHandling.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldHandling.scala
@@ -238,12 +238,16 @@ abstract class BaseFieldHolder[
     val nameTransform = (selector + " [name]") #> functionId
 
     initialValue.map { startValue =>
-      selector #> { ns: NodeSeq => ns match {
-        case elem: Elem if elem.label == "textarea" =>
-          (nameTransform & "^ *" #> serializeValue(startValue)) apply ns
-        case _ =>
-          (nameTransform & "^ [value]" #> serializeValue(startValue)) apply ns
-      } }
+      selector #> { ns: NodeSeq =>
+        val startValueBind =
+          ns match {
+            case elem: Elem if elem.label == "textarea" =>
+              "^ *" #> serializeValue(startValue)
+            case _ =>
+              "^ [value]" #> serializeValue(startValue)
+          }
+        (nameTransform & startValueBind) apply ns
+      }
     } getOrElse {
       nameTransform
     }

--- a/src/main/scala/com/hacklanta/formality/FieldHandling.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldHandling.scala
@@ -763,7 +763,13 @@ case class CheckboxFieldHolder(
 
     selector #> { ns: NodeSeq => ns match {
       case element: Elem =>
-        val checkbox = <input type="checkbox" name={functionId} value={serializeValue(initialValue)} />
+        val checkedValue = if (initialValue) {
+          Some(Text("checked"))
+        } else {
+          None
+        }
+
+        val checkbox = <input type="checkbox" name={functionId} value="true" checked={checkedValue} />
 
         element.attributes.foldLeft(checkbox)(_ % _) ++
         <input type="hidden" name={functionId} value="false" />

--- a/src/main/scala/com/hacklanta/formality/FieldHandling.scala
+++ b/src/main/scala/com/hacklanta/formality/FieldHandling.scala
@@ -342,6 +342,100 @@ case class SimpleFieldHolder[
   }
 }
 /**
+  * This case class is a variant of SimpleFieldHolder for textareas.
+  * 
+  * We need it because when setting default values for fields, we usually
+  * set the value attribute of the element, but for textareas we need to
+  * set the textarea's content.
+  */
+case class TextareaHolder[
+  FieldValueType,
+  ValidationType >: FieldValueType,
+  EventHandlerType >: FieldValueType
+](
+  selector: String,
+  initialValue: Box[FieldValueType],
+  validations: List[Validation[ValidationType]],
+  boxedValidations: List[Validation[Box[ValidationType]]],
+  eventHandlers: List[EventHandler[EventHandlerType]]
+)(
+  implicit valueConverter: (String)=>Box[FieldValueType],
+           valueSerializer: (FieldValueType)=>String
+) extends BaseFieldHolder[String, FieldValueType, ValidationType, EventHandlerType](
+            selector, initialValue, validations, boxedValidations, eventHandlers
+          ) {
+  protected def convertValue(incomingValue: String) = valueConverter(incomingValue)
+  protected def serializeValue(value: FieldValueType) = valueSerializer(value)
+
+  def validatingWith(validation: Validation[ValidationType]) = {
+    this.copy(
+      selector = selector,
+      validations = validation :: validations)
+  }
+  def validatingWith(boxedValidation: Validation[Box[ValidationType]])(implicit dummy: DummyImplicit) = {
+    this.copy(boxedValidations = boxedValidation :: boxedValidations)
+  }
+  def handlingEvent(eventHandler: EventHandler[EventHandlerType]) = {
+    this.copy(eventHandlers = eventHandler :: eventHandlers)
+  }
+
+  protected def generateFunctionIdAndHandler: String = {
+    // Awkward super-dirty, but we need to reference the function id in
+    // the handler, and we only get the function id after mapping the
+    // handler, so we have to go this route. As long as you don't run
+    // the handler before the fmapFunc runs, everything is peachy.
+    //
+    // WARNING: DON'T RUN THE HANDLER BEFORE THE FMAPFUNC RUNS.
+    //
+    // Kword? ;)
+    var functionId: String = null
+
+    def handler(incomingValue: String): Unit = {
+      convertValue(incomingValue) match {
+        case Full(convertedValue) =>
+          val validationErrors =
+            validations.reverse.flatMap(_(convertedValue)) ++
+            boxedValidations.reverse.flatMap(_(Full(convertedValue)))
+
+          addValidationErrors(validationErrors: _*)
+
+          if (validationErrors.isEmpty) {
+            fieldValue(Full(convertedValue))
+          } else {
+            fieldValue(Failure(convertedValue + " failed validations.") ~> validationErrors)
+          }
+
+        case failure @ Failure(failureError, _, _) =>
+          val validationErrors = boxedValidations.reverse.flatMap(_(failure))
+
+          fieldValue(failure ~> incomingValue)
+          addValidationErrors(failureError)
+
+        case Empty =>
+          fieldValue(Failure("Unrecognized response.") ~> incomingValue)
+          addValidationErrors("Unrecognized response.")
+      }
+    }
+
+    functionId = S.fmapFunc(handler _)(funcName => funcName)
+
+    functionId
+  }
+
+  override protected def baseTransform: CssSel = {
+    val functionId = fieldName.is
+
+    val nameTransform = (selector + " [name]") #> functionId
+
+    initialValue.map { startValue => 
+      nameTransform &
+      (selector + " *") #> serializeValue(startValue)
+    } getOrElse {
+      nameTransform
+    }
+  }
+}
+/**
  * This case class creates a field holder for a select field that gets a
  * `String` from the client. If `asRadioButtons` is `true`, the binder created
  * for this select field is designed to bind to radio buttons and their

--- a/src/main/scala/com/hacklanta/formality/Formality.scala
+++ b/src/main/scala/com/hacklanta/formality/Formality.scala
@@ -16,6 +16,10 @@ object Formality extends FieldValueHelpers {
     SimpleFieldHolder[T,T,T](selector, Empty, Nil, Nil, Nil)(valueConverter, valueSerializer)
   }
 
+  def textareaField(selector: String, initialValue: String): TextareaHolder[String,String,String] = {
+    TextareaHolder[String,String,String](selector, Full(initialValue), Nil, Nil, Nil)
+  }
+
   // Basic file upload field, spits out a FileParamHolder.
   def fileUploadField(selector: String): FileFieldHolder[FileParamHolder, FileParamHolder, FileParamHolder] = {
     FileFieldHolder(selector, Nil, Nil, Nil)(fph => Full(fph))

--- a/src/main/scala/com/hacklanta/formality/Formality.scala
+++ b/src/main/scala/com/hacklanta/formality/Formality.scala
@@ -12,6 +12,9 @@ object Formality extends FieldValueHelpers {
   def field[T](selector: String, initialValue: T)(implicit valueConverter: (String)=>Box[T], valueSerializer: (T)=>String): SimpleFieldHolder[T, T, T] = {
     SimpleFieldHolder(selector, Full(initialValue), Nil, Nil, Nil)(valueConverter, valueSerializer)
   }
+  def field[T](selector: String, initialValue: Box[T])(implicit valueConverter: (String)=>Box[T], valueSerializer: (T)=>String): SimpleFieldHolder[T, T, T] = {
+    SimpleFieldHolder(selector, initialValue, Nil, Nil, Nil)(valueConverter, valueSerializer)
+  }
   def field[T](selector: String)(implicit valueConverter: (String)=>Box[T], valueSerializer: (T)=>String): SimpleFieldHolder[T, T, T] = {
     SimpleFieldHolder[T,T,T](selector, Empty, Nil, Nil, Nil)(valueConverter, valueSerializer)
   }

--- a/src/main/scala/com/hacklanta/formality/Formality.scala
+++ b/src/main/scala/com/hacklanta/formality/Formality.scala
@@ -19,10 +19,6 @@ object Formality extends FieldValueHelpers {
     SimpleFieldHolder[T,T,T](selector, Empty, Nil, Nil, Nil)(valueConverter, valueSerializer)
   }
 
-  def textareaField(selector: String, initialValue: String): TextareaHolder[String,String,String] = {
-    TextareaHolder[String,String,String](selector, Full(initialValue), Nil, Nil, Nil)
-  }
-
   // Basic file upload field, spits out a FileParamHolder.
   def fileUploadField(selector: String): FileFieldHolder[FileParamHolder, FileParamHolder, FileParamHolder] = {
     FileFieldHolder(selector, Nil, Nil, Nil)(fph => Full(fph))

--- a/src/test/scala/com/hacklanta/formality/FieldSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/FieldSpec.scala
@@ -879,5 +879,18 @@ class FieldSpec extends Specification {
 
       nameForType("checkbox") must_== nameForType("hidden")
     }
+
+    "set the checked attribute if there is an initial value" in new SScope {
+      val formField = checkboxField(".boomdayada", true)
+
+      val resultingMarkup = <test-parent>{formField.binder(templateElement)}</test-parent>
+
+      resultingMarkup must \(
+        "input",
+        "type" -> "checkbox",
+        "name" -> ".*",
+        "checked" -> "checked"
+      )
+    }
   }
 }

--- a/src/test/scala/com/hacklanta/formality/FieldSpec.scala
+++ b/src/test/scala/com/hacklanta/formality/FieldSpec.scala
@@ -31,7 +31,7 @@ class FieldSpec extends Specification {
     }
   }
   
-  "Simple fields with an initial value" should {
+  "Simple non-textarea fields with an initial value" should {
     "only bind the name and value attributes" in new SScope {
       val formField = field[String](".boomdayada", "Dat value")
 
@@ -43,6 +43,53 @@ class FieldSpec extends Specification {
         "data-test-attribute" -> "bam",
         "name" -> ".*",
         "value" -> "Dat value"
+      )
+    }
+  }
+
+  "Simple textarea fields with an initial value" should {
+    "bind the name attribute and body" in new SScope {
+      val templateElement = <textarea class="boomdayada boomdayadan">Here's a test!</textarea>
+      val formField = field[String](".boomdayada", "Texty value")
+
+      val resultingMarkup = <test-parent>{formField.binder(templateElement)}</test-parent>
+
+      resultingMarkup must \(
+        "textarea",
+        "class" -> "boomdayada boomdayadan",
+        "name" -> ".*"
+      ) \> "Texty value"
+    }
+  }
+
+  "Simple fields with a Full Box for their initial value" should {
+    "set that initial value to the contents of the Box" in new SScope {
+      val formField = field[String](".boomdayada", Full("Dat value"))
+
+      val resultingMarkup = <test-parent>{formField.binder(templateElement)}</test-parent>
+
+      resultingMarkup must \(
+        "div",
+        "class" -> "boomdayada boomdayadan",
+        "data-test-attribute" -> "bam",
+        "name" -> ".*",
+        "value" -> "Dat value"
+      )
+    }
+  }
+
+  "Simple fields with an Empty Box for their initial value" should {
+    "leave the value attribute unchanged from the template" in new SScope {
+      val formField = field[String](".boomdayada", Empty)
+
+      val resultingMarkup = <test-parent>{formField.binder(templateElement)}</test-parent>
+
+      resultingMarkup must \(
+        "div",
+        "class" -> "boomdayada boomdayadan",
+        "data-test-attribute" -> "bam",
+        "name" -> ".*",
+        "value" -> "markup-value"
       )
     }
   }


### PR DESCRIPTION
Fixes #20.
Fixes #21.
Fixes #22.

# Description

1. We can't set defaults for textareas like we set defaults for non-textarea inputs. Non-textarea inputs have their default set by setting their `value` attribute. Textarea inputs have their default set by setting the element's content.

2. We need to be able to set an empty default value for a non-`String` field, for example a `Charset`. We provide constructors which take `Box[T]`s' for their `initialValue` in order to allow us to pass an `Empty` if there is no `T`.