### PR TITLE
1.1.0 Release Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ once reported on Github.
 
 ## Including
 
-You can include Formality directly as a dependency in your `build.sbt`:
+You can include Formality directly as a dependency in your `build.sbt`,
+suffixing the major and minor Lift version you are using (3.0 and 3.1 are
+currently supported):
 
 ```
 libraryDependencies ++= Seq(
-  "com.hacklanta" %% "lift-formality" % "1.0.0"
+  "com.hacklanta" %% "lift-formality_3.1" % "1.1.0"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "lift-formality"
 
 organization := "com.hacklanta"
 
-version := "1.1.0-SNAPSHOT"
+version := "1.1.0"
 
 scalaVersion := "2.11.12"
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ version := "1.1.0"
 
 scalaVersion := "2.11.12"
 
+// Disable package scaladocs, as 2.11.12 Scaladoc + Java 9 seems to go boom.
+publishArtifact in (Compile, packageDoc) := false
+
 liftVersion <<= liftVersion ?? "3.1.0"
 
 liftEdition <<= liftVersion apply { _.substring(0,3) }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.17-RC1


### PR DESCRIPTION
Mostly the dance here is to get everything set up for Java 9-based
compilation and packaging. That means Scala 2.11 and sbt 0.13 are
throwing some obstacles our way, but we'll take care of bumping Scala
and sbt after 1.1.0 goes out probably.

A 1.1.0 snapshot build for Lift 3.0 and 3.1 and Scala 2.11 has been
published with these new settings pending confirmation that things
are behaving.