### PR TITLE
Upgrade to 2.12.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 scala:
  - 2.11.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 
 scala:
  - 2.11.12
- - 2.12.6
+ - 2.12.9
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ organization := "com.hacklanta"
 
 version := "1.3.0-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.9"
 
-crossScalaVersions := Seq("2.12.6", "2.11.12")
+crossScalaVersions := Seq("2.12.9", "2.11.12")
 
 liftVersion := (liftVersion ?? "3.3.0").value
 


### PR DESCRIPTION
This should fix the issue we were having with the doc task and Lift 3.3.0, related to 3.3.0 being built on JDK 9+. The related Scala bug is scala/bug#11635; h/t to @SethTisue for chiming in to let us know it was being tracked so we could keep an eye on the fix landing!

Closes #30 .